### PR TITLE
Retrofit-Task

### DIFF
--- a/app/src/main/java/com/example/nebo/bakingapp/MainActivity.java
+++ b/app/src/main/java/com/example/nebo/bakingapp/MainActivity.java
@@ -16,12 +16,20 @@ import com.example.nebo.bakingapp.async.NetworkAsyncTaskLoader;
 import com.example.nebo.bakingapp.data.Data;
 import com.example.nebo.bakingapp.data.Recipe;
 import com.example.nebo.bakingapp.ui.RecipeStepDetailsFragment;
+import com.example.nebo.bakingapp.util.NetworkUtils;
 
 import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 import static com.example.nebo.bakingapp.async.NetworkAsyncTaskLoader.QUERY_TASK_ID;
 
 public class MainActivity extends AppCompatActivity {
+    private static final String TAG = "MAIN ACTIVITY";
+    private List<Recipe> mRecipes = null;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -31,25 +39,21 @@ public class MainActivity extends AppCompatActivity {
         FragmentManager manager = getSupportFragmentManager();
 
         manager.beginTransaction().add(R.id.fl_recipe_step_details, fragment).commit();
+        NetworkUtils.getRecipesFromNetwork(new RecipeNetworkHandler());
+    }
 
+    private class RecipeNetworkHandler implements Callback<List<Recipe>> {
 
-        LoaderManager loaderManager = getSupportLoaderManager();
-
-        if (loaderManager != null) {
-            Loader<List<Recipe>> loader = loaderManager.getLoader(QUERY_TASK_ID);
-
-            if (loader == null) {
-                loaderManager.initLoader(QUERY_TASK_ID,
-                        null,
-                        new NetworkAsyncTaskLoader(this)).forceLoad();
-            } else {
-                loaderManager.restartLoader(NetworkAsyncTaskLoader.QUERY_TASK_ID,
-                        null,
-                        new NetworkAsyncTaskLoader(this)).forceLoad();
+        @Override
+        public void onResponse(Call<List<Recipe>> call, Response<List<Recipe>> response) {
+            if (response != null && response.body() != null) {
+                MainActivity.this.mRecipes = response.body();
+                Log.d (TAG, "Number of recipes is " + Integer.toString(mRecipes.size()));
             }
         }
-        else {
-            Log.e("MainActivity", "Loader Manager is null.");
+
+        @Override
+        public void onFailure(Call<List<Recipe>> call, Throwable t) {
         }
     }
 }

--- a/app/src/main/java/com/example/nebo/bakingapp/util/NetworkUtils.java
+++ b/app/src/main/java/com/example/nebo/bakingapp/util/NetworkUtils.java
@@ -1,0 +1,41 @@
+package com.example.nebo.bakingapp.util;
+
+import com.example.nebo.bakingapp.data.Recipe;
+
+import java.util.List;
+
+import okhttp3.OkHttpClient;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+import retrofit2.http.GET;
+
+public class NetworkUtils {
+    private static final String sBaseEndPointAddress =
+            "https://d17h27t6h515a5.cloudfront.net/topher/2017/May/59121517_baking/";
+
+    private interface RecipeService {
+        @GET("baking.json")
+        Call<List<Recipe>> listRecipes();
+    }
+
+    public static void getRecipesFromNetwork(Callback<List<Recipe>> callback) {
+        // Build the retrofit element.
+        Retrofit retrofit = new Retrofit.Builder().
+                baseUrl(sBaseEndPointAddress).
+                addConverterFactory(GsonConverterFactory.create()).
+                client(new OkHttpClient()).
+                build();
+
+        // Get the client that will be associated with the retrofit element.
+        RecipeService recipeServiceClient = retrofit.create(RecipeService.class);
+
+        // Get the call instance that is associated with the client.
+        Call<List<Recipe>> call = recipeServiceClient.listRecipes();
+
+        // Enqueue the call to be handled by the retrofit element associated with the client that
+        // asynchronously handles the specified callback.
+        call.enqueue(callback);
+    }
+}


### PR DESCRIPTION
Removed the logic for the LoaderManager and NetworkAsyncTask from the `MainActivity` for retrieving the list of recipes from the network.

MainActivity is providing its own retrofit `Callback` that is supplied to the `NetworkUtils` class that performs the actual retrofit asynchronous call.