### PR TITLE
Master fragment Recipes

### DIFF
--- a/app/src/main/java/com/example/nebo/bakingapp/BakingActivity.java
+++ b/app/src/main/java/com/example/nebo/bakingapp/BakingActivity.java
@@ -6,11 +6,12 @@ import android.support.annotation.Nullable;
 import android.support.v4.app.FragmentManager;
 import android.support.v7.app.AppCompatActivity;
 
+import com.example.nebo.bakingapp.data.Recipe;
 import com.example.nebo.bakingapp.databinding.ActivityBakingBinding;
 import com.example.nebo.bakingapp.ui.RecipesFragment;
 import com.example.nebo.bakingapp.util.NetworkUtils;
 
-public class BakingActivity extends AppCompatActivity {
+public class BakingActivity extends AppCompatActivity implements RecipesFragment.OnClickRecipeListener {
     private ActivityBakingBinding mBinding = null;
 
     @Override
@@ -29,5 +30,10 @@ public class BakingActivity extends AppCompatActivity {
 
         // now need to provide some logic to actually get the recipes.
         NetworkUtils.getRecipesFromNetwork(recipesFragment);
+    }
+
+    @Override
+    public void onClickRecipe(Recipe recipe) {
+        // now can launch the actual intent from the activity instead of from the fragment.
     }
 }

--- a/app/src/main/java/com/example/nebo/bakingapp/BakingActivity.java
+++ b/app/src/main/java/com/example/nebo/bakingapp/BakingActivity.java
@@ -12,7 +12,19 @@ import com.example.nebo.bakingapp.databinding.ActivityBakingBinding;
 import com.example.nebo.bakingapp.ui.RecipesFragment;
 import com.example.nebo.bakingapp.util.NetworkUtils;
 
-public class BakingActivity extends AppCompatActivity implements RecipesFragment.OnClickRecipeListener {
+import java.util.ArrayList;
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class BakingActivity extends AppCompatActivity
+        implements
+        RecipesFragment.OnClickRecipeListener,
+        Callback<ArrayList<Recipe>>
+{
+
     private ActivityBakingBinding mBinding = null;
 
     @Override
@@ -27,10 +39,30 @@ public class BakingActivity extends AppCompatActivity implements RecipesFragment
         RecipesFragment recipesFragment = new RecipesFragment();
         FragmentManager fragmentManager = getSupportFragmentManager();
 
-        fragmentManager.beginTransaction().add(R.id.fl_recipes, recipesFragment).addToBackStack(null).commit();
+        fragmentManager.beginTransaction().add(mBinding.flRecipes.getId(), recipesFragment).addToBackStack(null).commit();
 
         // now need to provide some logic to actually get the recipes.
-        NetworkUtils.getRecipesFromNetwork(recipesFragment);
+        NetworkUtils.getRecipesFromNetwork(this);
+    }
+
+    @Override
+    public void onResponse(Call<ArrayList<Recipe>> call, Response<ArrayList<Recipe>> response) {
+        if (response != null && response.body() != null) {
+            Bundle fragmentArgs = new Bundle();
+
+            fragmentArgs.putParcelableArrayList(getString(R.string.key_recipes), response.body());
+
+            FragmentManager fragmentManager = getSupportFragmentManager();
+            RecipesFragment recipesFragment = new RecipesFragment();
+            recipesFragment.setArguments(fragmentArgs);
+
+            fragmentManager.beginTransaction().replace(mBinding.flRecipes.getId(), recipesFragment).commit();
+        }
+    }
+
+    @Override
+    public void onFailure(Call<ArrayList<Recipe>> call, Throwable t) {
+
     }
 
     @Override

--- a/app/src/main/java/com/example/nebo/bakingapp/BakingActivity.java
+++ b/app/src/main/java/com/example/nebo/bakingapp/BakingActivity.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.FragmentManager;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 
 import com.example.nebo.bakingapp.data.Recipe;
 import com.example.nebo.bakingapp.databinding.ActivityBakingBinding;
@@ -35,5 +36,6 @@ public class BakingActivity extends AppCompatActivity implements RecipesFragment
     @Override
     public void onClickRecipe(Recipe recipe) {
         // now can launch the actual intent from the activity instead of from the fragment.
+        Log.d ("BakingActivity onClickRecipe", recipe.getName() + " has been clicked.");
     }
 }

--- a/app/src/main/java/com/example/nebo/bakingapp/ui/RecipesFragment.java
+++ b/app/src/main/java/com/example/nebo/bakingapp/ui/RecipesFragment.java
@@ -19,6 +19,7 @@ import com.example.nebo.bakingapp.data.Recipe;
 import com.example.nebo.bakingapp.databinding.FragmentRecipesBinding;
 import com.example.nebo.bakingapp.viewholder.RecipeViewHolder;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import retrofit2.Call;
@@ -26,8 +27,7 @@ import retrofit2.Callback;
 import retrofit2.Response;
 
 public class RecipesFragment extends Fragment
-        implements Callback<List<Recipe>>,
-        AppAdapter.AdapterOnClickListener {
+        implements AppAdapter.AdapterOnClickListener {
 
     private FragmentRecipesBinding mBinding = null;
     private AppAdapter<Recipe, RecipeViewHolder<Recipe>> mAdapter = null;
@@ -66,6 +66,12 @@ public class RecipesFragment extends Fragment
                 container,
                 false);
 
+        ArrayList<Recipe> recipes = null;
+
+        if (getArguments() != null && getArguments().containsKey(getString(R.string.key_recipes))) {
+            recipes = getArguments().getParcelableArrayList(getString(R.string.key_recipes));
+        }
+
         LinearLayoutManager layoutManager =
                 new LinearLayoutManager(getContext(),
                         LinearLayoutManager.VERTICAL,
@@ -77,19 +83,9 @@ public class RecipesFragment extends Fragment
         mBinding.rvRecipes.setLayoutManager(layoutManager);
         mBinding.rvRecipes.setHasFixedSize(true);
 
+        mAdapter.setData(recipes);
+
         return mBinding.getRoot();
-    }
-
-    @Override
-    public void onResponse(Call<List<Recipe>> call, Response<List<Recipe>> response) {
-        if (response != null && response.body() != null) {
-            mAdapter.setData(response.body());
-        }
-    }
-
-    @Override
-    public void onFailure(Call<List<Recipe>> call, Throwable t) {
-
     }
 
     // This onClick is provided to the recycler view view handler objects.

--- a/app/src/main/java/com/example/nebo/bakingapp/ui/RecipesFragment.java
+++ b/app/src/main/java/com/example/nebo/bakingapp/ui/RecipesFragment.java
@@ -92,20 +92,14 @@ public class RecipesFragment extends Fragment
 
     }
 
+    // This onClick is provided to the recycler view view handler objects.
     @Override
     public void onClick(int position) {
-        // On click event has occurred, so obtain the desire recipe from the adapter.
         Recipe recipe = mAdapter.get(position);
 
-        if (recipe != null) {
-            // now will perform an intent to switch to the activity that is responsible for
-            // rendering the details associated with the recipe.
-            Intent intent = new Intent(getContext(), RecipeActivity.class);
-
-            // Before starting the activity need to setup the bundle for it.
-            intent.putExtra(getString(R.string.key_recipe), recipe);
-
-            startActivity(intent);
+        if (recipe != null && mCallback != null) {
+            // Calls the fragment's instance of the host provided callback.
+            mCallback.onClickRecipe(recipe);
         }
     }
 }

--- a/app/src/main/java/com/example/nebo/bakingapp/ui/RecipesFragment.java
+++ b/app/src/main/java/com/example/nebo/bakingapp/ui/RecipesFragment.java
@@ -31,9 +31,27 @@ public class RecipesFragment extends Fragment
 
     private FragmentRecipesBinding mBinding = null;
     private AppAdapter<Recipe, RecipeViewHolder<Recipe>> mAdapter = null;
-    private Context mContext;
+    private OnClickRecipeListener mCallback = null;
+
+    public interface OnClickRecipeListener {
+        void onClickRecipe(Recipe recipe);
+    }
 
     public RecipesFragment() {}
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+
+        try {
+            mCallback = (OnClickRecipeListener) context;
+        }
+        catch (ClassCastException e) {
+            throw new ClassCastException(
+                    context.toString() + " must implement OnClickRecipeListener."
+            );
+        }
+    }
 
     @Nullable
     @Override

--- a/app/src/main/java/com/example/nebo/bakingapp/util/NetworkUtils.java
+++ b/app/src/main/java/com/example/nebo/bakingapp/util/NetworkUtils.java
@@ -2,6 +2,7 @@ package com.example.nebo.bakingapp.util;
 
 import com.example.nebo.bakingapp.data.Recipe;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import okhttp3.OkHttpClient;
@@ -17,10 +18,10 @@ public class NetworkUtils {
 
     private interface RecipeService {
         @GET("baking.json")
-        Call<List<Recipe>> listRecipes();
+        Call<ArrayList<Recipe>> listRecipes();
     }
 
-    public static void getRecipesFromNetwork(Callback<List<Recipe>> callback) {
+    public static void getRecipesFromNetwork(Callback<ArrayList<Recipe>> callback) {
         // Build the retrofit element.
         Retrofit retrofit = new Retrofit.Builder().
                 baseUrl(sBaseEndPointAddress).
@@ -32,7 +33,7 @@ public class NetworkUtils {
         RecipeService recipeServiceClient = retrofit.create(RecipeService.class);
 
         // Get the call instance that is associated with the client.
-        Call<List<Recipe>> call = recipeServiceClient.listRecipes();
+        Call<ArrayList<Recipe>> call = recipeServiceClient.listRecipes();
 
         // Enqueue the call to be handled by the retrofit element associated with the client that
         // asynchronously handles the specified callback.

--- a/app/src/main/res/layout/activity_recipe.xml
+++ b/app/src/main/res/layout/activity_recipe.xml
@@ -21,6 +21,12 @@
             android:layout_height="wrap_content">
         </FrameLayout>
 
+        <FrameLayout
+            android:id="@+id/fl_recipe_details"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+        </FrameLayout>
+
         <!-- maybe something specific for navigation -->
         <FrameLayout
             android:id="@+id/fl_navigation"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="key_recipe" translatable="false">recipe</string>
     <string name="key_recipe_steps" translatable="false">recipe-steps</string>
     <string name="key_recipe_step" translatable="false">recipe-step</string>
+    <string name="key_recipes" translatable="false">recipes</string>
 </resources>


### PR DESCRIPTION
Originally the `RecipesFragment` contained application traversal logic.  However this is not the intended design and use of fragments.  The host activity should own this information while a fragment contains information only with respect to the UI.

Therefore this branch works on setting up the `BakingActivity` to perform the application logic, thus the retrofit async network task and the implicit intent launching of the `RecipeActivity` have been removed from the `RecipesFragment` logic.

The host activity in this case `BakingActivity` is now responsible for performing the retrofit async task and on successful response will replace the `RecipesFragment` with new data.