### PR TITLE
Recipe master fragment

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,8 @@
         </activity>
 
         <activity android:name=".RecipeActivity"
-            android:parentActivityName=".BakingActivity" >
+            android:parentActivityName=".BakingActivity"
+            android:launchMode="singleTop">
 
         </activity>
 

--- a/app/src/main/java/com/example/nebo/bakingapp/BakingActivity.java
+++ b/app/src/main/java/com/example/nebo/bakingapp/BakingActivity.java
@@ -1,5 +1,6 @@
 package com.example.nebo.bakingapp;
 
+import android.content.Intent;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -68,6 +69,9 @@ public class BakingActivity extends AppCompatActivity
     @Override
     public void onClickRecipe(Recipe recipe) {
         // now can launch the actual intent from the activity instead of from the fragment.
-        Log.d ("BakingActivity onClickRecipe", recipe.getName() + " has been clicked.");
+        Intent intent = new Intent(this, RecipeActivity.class);
+        intent.putExtra(getString(R.string.key_recipe), recipe);
+
+        startActivity(intent);
     }
 }

--- a/app/src/main/java/com/example/nebo/bakingapp/RecipeActivity.java
+++ b/app/src/main/java/com/example/nebo/bakingapp/RecipeActivity.java
@@ -8,12 +8,16 @@ import android.support.v7.app.AppCompatActivity;
 
 import com.example.nebo.bakingapp.data.Recipe;
 
+import com.example.nebo.bakingapp.data.RecipeStep;
 import com.example.nebo.bakingapp.databinding.ActivityRecipeBinding;
 import com.example.nebo.bakingapp.ui.RecipeIngredientFragment;
 import com.example.nebo.bakingapp.ui.RecipeNavigationFragment;
 import com.example.nebo.bakingapp.ui.RecipeStepsFragment;
+import com.example.nebo.bakingapp.ui.RecipesFragment;
 
-public class RecipeActivity extends AppCompatActivity {
+public class RecipeActivity extends AppCompatActivity
+        implements RecipeStepsFragment.OnClickRecipeStepListener
+{
     private Recipe mRecipe = null;
     private ActivityRecipeBinding mBinding = null;
 
@@ -56,6 +60,13 @@ public class RecipeActivity extends AppCompatActivity {
                 // add(R.id.fl_navigation, navigationFragment).
                 commit();
 
+    }
+
+    @Override
+    public void onRecipeStepClick(RecipeStep recipeStep) {
+        Intent intent = new Intent(this, RecipeStepActivity.class);
+        intent.putExtra(getString(R.string.key_recipe_step), recipeStep);
+        startActivity(intent);
     }
 
     /*

--- a/app/src/main/java/com/example/nebo/bakingapp/RecipeActivity.java
+++ b/app/src/main/java/com/example/nebo/bakingapp/RecipeActivity.java
@@ -5,6 +5,7 @@ import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 
 import com.example.nebo.bakingapp.data.Recipe;
 
@@ -25,6 +26,16 @@ public class RecipeActivity extends AppCompatActivity
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         mBinding = DataBindingUtil.setContentView(this, R.layout.activity_recipe);
+
+        if (savedInstanceState != null && savedInstanceState.containsKey(getString(R.string.key_recipe))) {
+            mRecipe = savedInstanceState.getParcelable(getString(R.string.key_recipe));
+        }
+        else if (savedInstanceState == null) {
+            Log.d("RecipeActivity", "savedInstanceState is null.");
+        }
+
+        Log.d("RecipeActivity", "OnCreate is called " + (mRecipe == null ? "recipe is null" : mRecipe.getName()));
+
 
         // Supporting going back to the list of recipes.
         if (getSupportActionBar() != null) {
@@ -60,6 +71,16 @@ public class RecipeActivity extends AppCompatActivity
                 // add(R.id.fl_navigation, navigationFragment).
                 commit();
 
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        if (mRecipe != null) {
+            outState.putParcelable(getString(R.string.key_recipe), mRecipe);
+            Log.d("onSavedInstanceState", "saved " + mRecipe.getName());
+        }
     }
 
     @Override

--- a/app/src/main/java/com/example/nebo/bakingapp/ui/RecipeStepsFragment.java
+++ b/app/src/main/java/com/example/nebo/bakingapp/ui/RecipeStepsFragment.java
@@ -1,5 +1,6 @@
 package com.example.nebo.bakingapp.ui;
 
+import android.content.Context;
 import android.content.Intent;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
@@ -26,8 +27,27 @@ public class RecipeStepsFragment extends Fragment implements AppAdapter.AdapterO
     private FragmentRecipeStepsBinding mBinding = null;
     private AppAdapter<RecipeStep, RecipeStepViewHolder<RecipeStep>> mAdapter = null;
     private List<RecipeStep> mRecipeSteps = null;
+    private OnClickRecipeStepListener mCallback = null;
+
+    public interface OnClickRecipeStepListener {
+        void onRecipeStepClick(RecipeStep recipeStep);
+    }
 
     public RecipeStepsFragment() {}
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+
+        try {
+            mCallback = (OnClickRecipeStepListener) context;
+        }
+        catch (ClassCastException e) {
+            throw new ClassCastException(
+                    e.toString() + " must implement the OnClickRecipeStepListener interface."
+            );
+        }
+    }
 
     @Nullable
     @Override
@@ -63,12 +83,8 @@ public class RecipeStepsFragment extends Fragment implements AppAdapter.AdapterO
     public void onClick(int position) {
         RecipeStep recipeStep = mAdapter.get(position);
 
-        // Explicit intent creation.
-        Intent intent = new Intent(getContext(), RecipeStepActivity.class);
-        intent.putExtra(getString(R.string.key_recipe_step), recipeStep);
-
-        startActivity(intent);
-
-        Log.d ("RecipeStepFragment", "Position Clicked " + Integer.toString(position));
+        if (mCallback != null) {
+            mCallback.onRecipeStepClick(recipeStep);
+        }
     }
 }

--- a/app/src/main/res/layout/activity_recipe.xml
+++ b/app/src/main/res/layout/activity_recipe.xml
@@ -21,19 +21,29 @@
             android:layout_height="wrap_content">
         </FrameLayout>
 
-        <FrameLayout
-            android:id="@+id/fl_recipe_details"
+        <!--
+        <LinearLayout
+            android:orientation="horizontal"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
-        </FrameLayout>
+            android:layout_height="match_parent"
+            android:baselineAligned="false">
+            -->
+            <FrameLayout
+                android:id="@+id/fl_recipe_details"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                >
+            </FrameLayout>
 
-        <!-- maybe something specific for navigation -->
-        <FrameLayout
-            android:id="@+id/fl_navigation"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:visibility="invisible">
-        </FrameLayout>
+            <!-- maybe something specific for navigation -->
+            <FrameLayout
+                android:id="@+id/fl_navigation"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="invisible"
+                >
+            </FrameLayout>
+        <!-- </LinearLayout> -->
 
     </android.support.constraint.ConstraintLayout>
 </layout>


### PR DESCRIPTION
Applied the removal of application view traversal from the RecipeStepsFragment and is now hosted in the RecipeActivity host java code.

Also this fixes the fact that the `onSavedInstance` data was not available due to the RecipeActivity not being launched as `singleTop`.