### PR TITLE
[BUG] SharedPreferences on new Recipe for Tablet+

### DIFF
--- a/app/src/main/java/com/example/nebo/bakingapp/RecipeActivity.java
+++ b/app/src/main/java/com/example/nebo/bakingapp/RecipeActivity.java
@@ -90,8 +90,12 @@ public class RecipeActivity extends AppCompatActivity
             if (mRecipe != null) {
                 recipeStepsFragmentArgs.putParcelableArrayList(getString(R.string.key_recipe_steps),
                         mRecipe.getSteps());
-                sharedPreferences.edit().putString(getString(R.string.key_recipe),
-                        mRecipe.getName()).apply();
+                if (previousRecipe != null && !previousRecipe.equals(mRecipe.getName())) {
+                    sharedPreferences.edit().
+                            putString(getString(R.string.key_recipe), mRecipe.getName()).
+                            putInt(getString(R.string.key_recipe_step_id), -1).
+                            apply();
+                }
                 BakingWidgetProvider.sendRefreshBoardcast(getApplicationContext());
             }
 


### PR DESCRIPTION
BUG Description

Currently was previously just taking in a previous recipe's state of
stepid for a new recipe.  This means that the detail step will be set to
the last recipe's step.

Related Issues
- #41
- #30
- #18